### PR TITLE
Do not read the whole tar archive from Docker into memory

### DIFF
--- a/docker_squash/image.py
+++ b/docker_squash/image.py
@@ -321,7 +321,14 @@ class Image(object):
                 image = self.docker.get_image(image_id)
 
                 with open(tar_file, 'wb') as f:
-                    f.write(image.data)
+                    while True:
+                        # Read about 10 MB of the tar archive
+                        data = image.read(1024000)
+
+                        if not data:
+                            break
+
+                        f.write(data)
 
                 self.log.info("Image saved!")
                 return True


### PR DESCRIPTION
From now on we read the image in chunks, about 10MB and save them
in a file.

This is not a perfect code, but at least does the job. Maybe it'll
be improved later.

Fixes #81.