### PR TITLE
Do not require to specify the tag for the squashed image

### DIFF
--- a/docker_squash/image.py
+++ b/docker_squash/image.py
@@ -143,7 +143,8 @@ class Image(object):
         # Location of the tar archive with squashed layers
         self.squashed_tar = os.path.join(self.squashed_dir, "layer.tar")
 
-        self.image_name, self.image_tag = self._parse_image_name(self.tag)
+        if self.tag:
+            self.image_name, self.image_tag = self._parse_image_name(self.tag)
 
         # The image id or name of the image to be squashed
         try:
@@ -228,8 +229,10 @@ class Image(object):
 
     def load_squashed_image(self):
         self._load_image(self.new_image_dir)
-        self.log.info("Image registered in Docker daemon as %s:%s" %
-                      (self.image_name, self.image_tag))
+
+        if self.tag:
+            self.log.info("Image registered in Docker daemon as %s:%s" %
+                          (self.image_name, self.image_tag))
 
     def _files_in_layers(self, layers, directory):
         """
@@ -391,6 +394,10 @@ class Image(object):
     def _generate_repositories_json(self, repositories_file, image_id, name, tag):
         if not image_id:
             raise SquashError("Provided image id cannot be null")
+
+        if name == tag == None:
+            self.log.debug("No name and tag provided for the image, skipping generating repositories file")
+            return
 
         repos = {}
         repos[name] = {}

--- a/docker_squash/v2_image.py
+++ b/docker_squash/v2_image.py
@@ -107,7 +107,10 @@ class V2Image(Image):
     def _generate_manifest_metadata(self, image_id, image_name, image_tag, old_image_manifest, layer_paths_to_move, layer_path_id=None):
         manifest = OrderedDict()
         manifest['Config'] = "%s.json" % image_id
-        manifest['RepoTags'] = ["%s:%s" % (image_name, image_tag)]
+
+        if image_name and image_tag:
+            manifest['RepoTags'] = ["%s:%s" % (image_name, image_tag)]
+
         manifest['Layers'] = old_image_manifest[
             'Layers'][:len(layer_paths_to_move)]
 

--- a/tests/test_unit_v1_image.py
+++ b/tests/test_unit_v1_image.py
@@ -164,6 +164,10 @@ class TestGenerateRepositoriesJSON(unittest.TestCase):
                 str(cm.exception), 'Provided image id cannot be null')
             mock_file().write.assert_not_called()
 
+    def test_should_not_generate_repositories_if_name_and_tag_is_missing(self):
+        self.squash._generate_repositories_json('file', 'abcd', None, None)
+        self.log.debug.assert_called_with("No name and tag provided for the image, skipping generating repositories file")
+
 
 class TestMarkerFiles(unittest.TestCase):
 


### PR DESCRIPTION
If you do not specify the tag, the image will bre registered
or saved with out any name, just layers.

Fixes #66.