### PR TITLE
added sys.exit(1) on KeyboardInterrupt

### DIFF
--- a/docker_squash/cli.py
+++ b/docker_squash/cli.py
@@ -62,6 +62,7 @@ class CLI(object):
                           from_layer=args.from_layer, tag=args.tag, output_path=args.output_path, tmp_dir=args.tmp_dir, development=args.development).run()
         except KeyboardInterrupt:
             self.log.error("Program interrupted by user, exiting...")
+            sys.exit(1)
         except:
             e = sys.exc_info()[1]
 


### PR DESCRIPTION
> added sys.exit(1) on KeyboardInterrupt

Fastfix. This is required because if you write bash script and ctrl-c on docker-squash, it doesn't interrupt bash script and makes a lot of problems ;)