### PR TITLE
Do not skip marker files when files in tar are prefixed

### DIFF
--- a/docker_squash/image.py
+++ b/docker_squash/image.py
@@ -492,15 +492,21 @@ class Image(object):
                     "Skipping '%s' marker file, this file was added earlier for some reason..." % marker.name)
                 continue
 
+            # https://github.com/goldmann/docker-squash/issues/108
+            # Some tar archives do have the filenames prefixed with './'
+            # which does not have any effect when we unpack the tar achive,
+            # but when processing tar content - we see this.
+            actual_files = [actual_file, "./%s" % actual_file, "%s/" % actual_file, ".%s/" % actual_file]
+
             if files_in_layers:
                 for files in files_in_layers.values():
-                    if actual_file in files or "%s/" % actual_file in files:
+                    if set(files).intersection(actual_files):
                         should_be_added_back = True
                         break
             else:
                 # There are no previous layers, so we need to add it back
                 # In fact this shouldn't happen since having a marker file
-                # where there is no previous layer doesn not make sense.
+                # where there is no previous layer does not make sense.
                 should_be_added_back = True
 
             if should_be_added_back:


### PR DESCRIPTION
It turns out that some tar archives have a ./ prefix
added for each file. Until now we compared files paths directly.
This comparison was not working, because both strings were different
(etc/fstab vs. ./etc/fstab).

Fixes #108