### PR TITLE
Symlinks not added to the image for some images

### DIFF
--- a/docker_squash/image.py
+++ b/docker_squash/image.py
@@ -636,7 +636,7 @@ class Image(object):
                         squashed_files.append(normalized_name)
 
             # This list shouldn't be that long
-            for member in skipped_hard_links.values() + skipped_sym_links.values():
+            for member in list(skipped_hard_links.values()) + list(skipped_sym_links.values()):
                 normalized_name = self._normalize_path(member.name)
                 normalized_linkname = self._normalize_path(member.linkname)
                 # We need to check if we should skip adding back the hard link

--- a/tests/test_integ_squash.py
+++ b/tests/test_integ_squash.py
@@ -754,7 +754,7 @@ class TestIntegSquash(IntegSquash):
 
     def test_should_squash_every_layer_from_an_image_from_docker_hub(self):
         dockerfile = '''
-        FROM python:3.5.1-alpine
+        FROM python:3.5-alpine
         '''
 
         with self.Image(dockerfile) as image:

--- a/tests/test_integ_squash.py
+++ b/tests/test_integ_squash.py
@@ -762,6 +762,23 @@ class TestIntegSquash(IntegSquash):
                 self.assertEqual(
                     len(squashed_image.layers), 1)
 
+    # https://github.com/goldmann/docker-squash/issues/111
+    def test_correct_symlinks_squashing(self):
+        dockerfile = '''
+        FROM %s
+        RUN mkdir -p /zzz
+        RUN ln -s /zzz /xxx
+        ''' % TestIntegSquash.BUSYBOX_IMAGE
+
+        with self.Image(dockerfile) as image:
+            with self.SquashedImage(image) as squashed_image:
+                squashed_image.assertFileExists('zzz')
+                squashed_image.assertFileExists('xxx')
+
+                with self.Container(squashed_image) as container:
+                    container.assertFileExists('zzz')
+                    container.assertFileExists('xxx')
+
 
 class NumericValues(IntegSquash):
     @classmethod


### PR DESCRIPTION
For some images it could happen that symlink was not added back
to the image because the target file was not added yet.

In fact the logic is not correct either, so #112 was created.

Additionally normalize paths to be sure we are talking about the
same file.

Fixes #111.