### PR TITLE
ApplyLayer duplicates of file paths not supported stdout

### DIFF
--- a/docker_squash/image.py
+++ b/docker_squash/image.py
@@ -538,7 +538,7 @@ class Image(object):
     def _normalize_path(self, path):
         return os.path.normpath(os.path.join("/", path))
 
-    def _add_hardlinks(self, squashed_tar, squashed_files, to_skip, files_in_layers_to_move, skipped_hard_links):
+    def _add_hardlinks(self, squashed_tar, squashed_files, to_skip, skipped_hard_links):
         for layer, hardlinks_in_layer in enumerate(skipped_hard_links):
             # We need to start from 1, that's why we bump it here
             current_layer = layer+1
@@ -559,23 +559,6 @@ class Image(object):
                 # 3. hard link is already in squashed files
                 # 4. hard link target is NOT in already squashed files
                 if layer_skip_name and current_layer > layer_skip_name or layer_skip_linkname and current_layer > layer_skip_linkname or normalized_name in squashed_files or normalized_linkname not in squashed_files:
-
-                    # Currently this code is not used, because when adding a hard link
-                    # to a file which exists in the lower layer Docker *copies* that
-                    # file. As a result we do not have a hard link but a regular file
-                    # instead. Not sure if this will be solved in newer Docker versions
-                    # but let's keep this code for now.
-                    if files_in_layers_to_move:
-                        for files in six.itervalues(files_in_layers_to_move):
-                            if normalized_linkname in files:
-                                # TODO: check if we need to take into account marker files
-                                #       in other layers
-                                self.log.debug("Found a hard link '%s' to file '%s' existing in moved layers, adding it back" % (
-                                    normalized_name, normalized_linkname))
-                                squashed_files.append(normalized_name)
-                                squashed_tar.addfile(member)
-                                continue
-
                     self.log.debug("Found a hard link '%s' to a file which is marked to be skipped: '%s', skipping link too" % (
                         normalized_name, normalized_linkname))
                 else:
@@ -735,7 +718,7 @@ class Image(object):
 
                     skipped_hard_links.append(skipped_hard_link_files)
 
-            self._add_hardlinks(squashed_tar, squashed_files, to_skip, files_in_layers_to_move, skipped_hard_links)
+            self._add_hardlinks(squashed_tar, squashed_files, to_skip, skipped_hard_links)
             self._add_symlinks(squashed_tar, squashed_files, to_skip, skipped_sym_links)
 
             if files_in_layers_to_move:

--- a/tests/test_integ_squash.py
+++ b/tests/test_integ_squash.py
@@ -883,6 +883,19 @@ class TestIntegSquash(IntegSquash):
                     container.assertFileExists('dir/dir')
                     container.assertFileExists('newdir/file')
 
+    def test_should_not_add_hard_link_if_exists_in_other_squashed_layer(self):
+        dockerfile = '''
+        FROM %s
+        RUN echo "base" > file && ln file link
+        RUN echo "first layer" > file && ln -f file link
+        RUN echo "second layer" > file && ln -f file link
+        ''' % TestIntegSquash.BUSYBOX_IMAGE
+
+        with self.Image(dockerfile) as image:
+            with self.SquashedImage(image, 2, numeric=True) as squashed_image:
+                with self.Container(squashed_image) as container:
+                    pass
+
 
 class NumericValues(IntegSquash):
     @classmethod


### PR DESCRIPTION
When we add hard link and the target file multiple times in
multiple layers, then we squash it - we add more than once
that hard link to the squashed archive.

Fixes #118