### PR TITLE
Added a simple Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+/*
+!docker_squash
+!requirements.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,3 @@
+FROM python:3-onbuild
+MAINTAINER "https://github.com/goldmann/docker-squash"
+ENTRYPOINT [ "python", "-m", "docker_squash.cli" ]


### PR DESCRIPTION
I've been wrestling with some conflicting dependencies for docker-squash and other pip-installed software on my machine. I realise the Python-way around this is probably to set up and use a virtualenv. But that's a bit of added complexity for someone using Docker who just wants their images squashed.

I'd suggest this project include a Dockerfile, and set up an automated public build of it on Docker hub or a similar service. This lets someone use docker-squash while having only the dependency of Docker itself. (Might conflict with the goal of #24, but I think it's quite nice for a Docker CLI utility)

(Went with a URL for MAINTAINER because a [single email address felt presumptive](http://blog.oddbit.com/2015/04/27/suggestions-for-the-docker-maintainer-directive/), but feel free to set it to whatever you like)

To use the image, you'd mount the Docker socket into the container (a common pattern for things like nginx-proxy), something like:

```
docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock \
  dominics/docker-squash:latest <docker-squash CLI args>
```
