### PR TITLE
Remove old image dir immediately after squashing

### DIFF
--- a/docker_squash/image.py
+++ b/docker_squash/image.py
@@ -217,7 +217,8 @@ class Image(object):
         self.log.info("Squashing image '%s'..." % self.image)
 
     def _after_squashing(self):
-        pass
+        self.log.debug("Removing from disk already squashed layers...")
+        shutil.rmtree(self.old_image_dir, ignore_errors=True)
 
     def layer_paths(self):
         """


### PR DESCRIPTION
This will let us save some space before we produce the
final tar image and (potentially) load it back to the daemon.

Fixes #133