### PR TITLE
Use image metadata instead of history to get the layers IDs

### DIFF
--- a/docker_squash/image.py
+++ b/docker_squash/image.py
@@ -343,9 +343,7 @@ class Image(object):
 
     def _read_layers(self, layers, image_id):
         """ Reads the JSON metadata for specified layer / image id """
-
-        for layer in self.docker.history(image_id):
-            layers.append(layer['Id'])
+        layers.extend(self.docker.inspect_image(image_id)['RootFS']['Layers'])
 
     def _parse_image_name(self, image):
         """


### PR DESCRIPTION
Following the landing of content-addressable storage in Docker 1.10, ```docker history``` is not the primary source for actual stored layers anymore. When using the history API, some layers show as "missing" and the total count is then incorrect.

This fixes squashing when specifying a custom number of last layers to squash.