### PR TITLE
Tweak layers slightly

### DIFF
--- a/docker_squash/image.py
+++ b/docker_squash/image.py
@@ -158,8 +158,6 @@ class Image(object):
         # Read all layers in the image
         self._read_layers(self.old_image_layers, self.old_image_id)
 
-        self.old_image_layers.reverse()
-
         self.log.info("Old image has %s layers", len(self.old_image_layers))
         self.log.debug("Old layers: %s", self.old_image_layers)
 
@@ -344,8 +342,7 @@ class Image(object):
     def _read_layers(self, layers, image_id):
         """ Reads the JSON metadata for specified layer / image id """
 
-        for layer in self.docker.history(image_id):
-            layers.append(layer['Id'])
+        layers.extend(self.docker.inspect_image(image_id)['RootFS']['Layers'])
 
     def _parse_image_name(self, image):
         """

--- a/docker_squash/image.py
+++ b/docker_squash/image.py
@@ -107,7 +107,10 @@ class Image(object):
             return None
 
         try:
-            squash_id = self.docker.inspect_image(layer)['Id']
+            if layer.startswith("sha256:"):
+                 squash_id = layer
+            else:
+                 squash_id = self.docker.inspect_image(layer)['Id']
         except:
             raise SquashError(
                 "Could not get the layer ID to squash, please check provided 'layer' argument: %s" % layer)


### PR DESCRIPTION
I have a multistep build process where we're building images on top of images and then finally squashing the whole stack back to a known base. This works fine with docker-squash when I run everything locally because none of the layers are ever 'missing'. However, when we use this as part of our CI system the various intermediate stages are pushed to a remote repo and so we lose the ids of some layers -- they're still there if you look at the `inspect` output but they're 'missing' in the output from `history`.

Anyway, this is just a little local experiment I did to see if I could get squashing to work within our limitations and it appears to work just fine.

The first commit is essentially a reimplementation of #148.

Feedback welcome, python is not my primary language.