### PR TITLE
minor: better explain what the --tmp-dir option really does

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,7 +72,7 @@ Usage
                             specified will squash all layers in the image
       -t TAG, --tag TAG     Specify the tag to be used for the new image. By
                             default it'll be set to 'image' argument
-      --tmp-dir TMP_DIR     Temporary directory to be used
+      --tmp-dir TMP_DIR     Temporary directory to be created and used
       --output-path OUTPUT_PATH
                             Path where the image should be stored after squashing.
                             If not provided, image will be loaded into Docker

--- a/docker_squash/cli.py
+++ b/docker_squash/cli.py
@@ -68,7 +68,7 @@ class CLI(object):
         parser.add_argument(
             '-c', '--cleanup', action='store_true', help="Remove source image from Docker after squashing")
         parser.add_argument(
-            '--tmp-dir', help='Temporary directory to be used')
+            '--tmp-dir', help='Temporary directory to be created and used')
         parser.add_argument(
             '--output-path', help='Path where the image should be stored after squashing. If not provided, image will be loaded into Docker daemon')
 


### PR DESCRIPTION
I had no idea that this option actually creates the directory and at the end it is removed. So I used it this way:

```bash
docker-squash --tmp-dir /home/jkremser/Downloads <hash>
```
And it failed with:

```bash
...
2017-11-27 21:30:48,854 root         ERROR    Preparing temporary directory failed
...
```
and deleted my `~/Downloads` :(

That's the reasoning behind opening this simple PR. The word 'created' should protect people from using the existing directories.