### PR TITLE
Use specific error for case when squashing is unnecessary

### DIFF
--- a/docker_squash/cli.py
+++ b/docker_squash/cli.py
@@ -5,6 +5,7 @@ import logging
 import sys
 
 from docker_squash import squash
+from docker_squash.errors import SquashError
 from docker_squash.version import version
 
 
@@ -97,6 +98,9 @@ class CLI(object):
 
             self.log.error(
                 "Execution failed, consult logs above. If you think this is our fault, please file an issue: https://github.com/goldmann/docker-squash/issues, thanks!")
+
+            if isinstance(e, SquashError):
+                sys.exit(e.code)
 
             sys.exit(1)
 

--- a/docker_squash/errors.py
+++ b/docker_squash/errors.py
@@ -4,4 +4,7 @@ class Error(Exception):
 
 
 class SquashError(Error):
-    pass
+    code = 1
+
+class SquashUnnecessaryError(SquashError):
+    code = 2

--- a/docker_squash/image.py
+++ b/docker_squash/image.py
@@ -10,7 +10,7 @@ import six
 import tarfile
 import tempfile
 
-from docker_squash.errors import SquashError
+from docker_squash.errors import SquashError, SquashUnnecessaryError
 
 if not six.PY3:
     import docker_squash.lib.xtarfile
@@ -193,9 +193,11 @@ class Image(object):
 
         self.log.info("Checking if squashing is necessary...")
 
-        if len(self.layers_to_squash) <= 1:
-            raise SquashError("%s layer(s) in this image marked to squash, no squashing is required" % len(
-                self.layers_to_squash))
+        if len(self.layers_to_squash) < 1:
+            raise SquashError("Invalid number of layers to squash: %s" % len(self.layers_to_squash))
+
+        if len(self.layers_to_squash) == 1:
+            raise SquashUnnecessaryError("Single layer marked to squash, no squashing is required")
 
         self.log.info("Attempting to squash last %s layers...",
                       number_of_layers)

--- a/tests/test_integ_squash.py
+++ b/tests/test_integ_squash.py
@@ -12,7 +12,7 @@ from io import BytesIO
 import uuid
 
 from docker_squash.squash import Squash
-from docker_squash.errors import SquashError
+from docker_squash.errors import SquashError, SquashUnnecessaryError
 from docker_squash.lib import common
 
 if not six.PY3:
@@ -612,11 +612,11 @@ class TestIntegSquash(IntegSquash):
         ''' % TestIntegSquash.BUSYBOX_IMAGE
 
         with self.Image(dockerfile) as image:
-            with self.assertRaises(SquashError) as cm:
+            with self.assertRaises(SquashUnnecessaryError) as cm:
                 with self.SquashedImage(image, 1) as squashed_image:
                     pass
 
-        self.assertEquals(str(cm.exception), '1 layer(s) in this image marked to squash, no squashing is required')
+        self.assertEquals(str(cm.exception), 'Single layer marked to squash, no squashing is required')
 
     # https://github.com/goldmann/docker-scripts/issues/52
     # Test may be misleading, but squashing all layers makes sure we hit
@@ -971,6 +971,11 @@ class NumericValues(IntegSquash):
     def test_should_not_squash_zero_number_of_layers(self):
         with self.assertRaisesRegexp(SquashError, "Number of layers to squash cannot be less or equal 0, provided: 0"):
             with self.SquashedImage(NumericValues.image, 0, numeric=True):
+                pass
+
+    def test_should_not_squash_single_layer(self):
+        with self.assertRaisesRegexp(SquashUnnecessaryError, "Single layer marked to squash, no squashing is required"):
+            with self.SquashedImage(NumericValues.image, 1, numeric=True):
                 pass
 
     def test_should_squash_2_layers(self):

--- a/tests/test_unit_squash.py
+++ b/tests/test_unit_squash.py
@@ -9,7 +9,7 @@ from docker_squash.errors import SquashError
 
 
 class TestSquash(unittest.TestCase):
-    
+
     def setUp(self):
         self.log = mock.Mock()
         self.docker_client = mock.Mock()
@@ -31,7 +31,7 @@ class TestSquash(unittest.TestCase):
     def test_should_not_cleanup_after_squashing(self, v2_image):
         squash = Squash(self.log, 'image', self.docker_client, load_image=True)
         squash.run()
-    
+
         v2_image.cleanup.assert_not_called()
 
     @mock.patch('docker_squash.squash.V2Image')
@@ -39,5 +39,5 @@ class TestSquash(unittest.TestCase):
         self.docker_client.inspect_image.return_value = {'Id': "abcdefgh"}
         squash = Squash(self.log, 'image', self.docker_client, load_image=True, cleanup=True)
         squash.run()
-    
+
         self.docker_client.remove_image.assert_called_with('abcdefgh', force=False, noprune=False)


### PR DESCRIPTION
Additionally such case, if squashing was started via CLI, the resturn
code is set to 2. This code is now reserved for a case where squashing
is not necessary.

Fixes #141