### PR TITLE
Handle opaque directories

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ jobs:
       - checkout
       - run: docker version
       - run: docker info
-      - run: pip install tox --user
+      - run: pip install tox zipp==0.5.2 --user
       - run: echo 'export PATH=~/.local/bin:$PATH' >> $BASH_ENV
       - run: pyenv local 2.7.12 3.5.2 3.6.5 3.7.0
       - run: |


### PR DESCRIPTION
Opaque directories are special case whiteout files. In case
an opaque directory is found in a layer, all content inside
of this rectory in this layer should be copied to the squashed
layer, but any content in layers below that layer on the
opaque directory path must be ignored.

Fixes #186