### PR TITLE
Drop Python 3.5 support

### DIFF
--- a/.github/workflows/squash.yml
+++ b/.github/workflows/squash.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.5', '3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
+        python-version: ['3.6', '3.7', '3.8', '3.9', '3.10', '3.11']
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,6 @@ CIRCLE_NODE_INDEX ?= 0
 test: prepare
 	tox -- tests
 
-test-py35: prepare
-	tox -e py35 -- tests
-
 test-py36: prepare
 	tox -e py36 -- tests
 

--- a/README.rst
+++ b/README.rst
@@ -41,7 +41,7 @@ From PyPi
 
     $ pip install docker-squash
 
-It is supported on Python 3.5 and above.
+It is supported on Python 3.6 and above.
 
 Usage
 -----
@@ -214,4 +214,3 @@ Let's confirm the image structure now:
     6ee235cf4473        3 weeks ago         /bin/sh -c #(nop) LABEL name=CentOS Base Imag   0 B
     474c2ee77fa3        3 weeks ago         /bin/sh -c #(nop) ADD file:72852fc7626d233343   196.6 MB
     1544084fad81        6 months ago        /bin/sh -c #(nop) MAINTAINER The CentOS Proje   0 B
-

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37,py38,py39,py310,py311
+envlist = py36,py37,py38,py39,py310,py311
 
 [testenv]
 passenv=CI,HOME


### PR DESCRIPTION
It is EOL according to https://devguide.python.org/versions and this avoids typing issues shown in https://github.com/goldmann/docker-squash/pull/225