### PR TITLE
Use packaging.version instead of distutils.StrictVersion

### DIFF
--- a/docker_squash/squash.py
+++ b/docker_squash/squash.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
 
 import os
-from distutils.version import StrictVersion
 
 import docker
+from packaging import version as packaging_version
 
 from docker_squash.errors import SquashError
 from docker_squash.lib import common
@@ -64,7 +64,9 @@ class Squash(object):
                 % self.output_path
             )
 
-        if StrictVersion(docker_version["ApiVersion"]) >= StrictVersion("1.22"):
+        if packaging_version.parse(
+            docker_version["ApiVersion"]
+        ) >= packaging_version.parse("1.22"):
             image = V2Image(
                 self.log,
                 self.docker,

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 docker
+packaging


### PR DESCRIPTION
distutils was deprecated in Python 3.11 and removed in Python 3.12