### PR TITLE
Revert "Podman compatibility"

### DIFF
--- a/docker_squash/image.py
+++ b/docker_squash/image.py
@@ -186,11 +186,12 @@ class Image(object):
         try:
             number_of_layers = int(self.from_layer)
 
-            self.log.debug("We detected number of layers as the argument to squash")
+            self.log.debug(
+                f"We detected number of layers ({number_of_layers}) as the argument to squash"
+            )
         except ValueError:
-            self.log.debug("We detected layer as the argument to squash")
-
             squash_id = self._squash_id(self.from_layer)
+            self.log.debug(f"We detected layer ({squash_id}) as the argument to squash")
 
             if not squash_id:
                 raise SquashError(

--- a/docker_squash/squash.py
+++ b/docker_squash/squash.py
@@ -143,8 +143,11 @@ class Squash(object):
             # Load squashed image into Docker
             image.load_squashed_image()
 
-        # Clean up all temporary files
-        image.cleanup()
+        # If development mode is not enabled, make sure we clean up the
+        # temporary directory
+        if not self.development:
+            # Clean up all temporary files
+            image.cleanup()
 
         # Remove the source image - this is the only possible way
         # to remove orphaned layers from Docker daemon at the build time.

--- a/docker_squash/v2_image.py
+++ b/docker_squash/v2_image.py
@@ -16,9 +16,6 @@ class V2Image(Image):
     def _before_squashing(self):
         super(V2Image, self)._before_squashing()
 
-        # New OCI Archive format type
-        self.oci_format = True
-
         # Read old image manifest file
         self.old_image_manifest = self._get_manifest()
         self.log.debug(
@@ -378,6 +375,8 @@ class V2Image(Image):
 
     def _get_manifest(self):
         if os.path.exists(os.path.join(self.old_image_dir, "index.json")):
+            # New OCI Archive format type
+            self.oci_format = True
             # Not using index.json to extract manifest details as while the config
             # sha could be extracted via some indirection i.e.
             #


### PR DESCRIPTION
This reverts commit 0030222 from #248 

Fixes #249 

The change for podman in retrospect is not complete. This library is still tied to docker-py to load/save the images so its not clear why that change was instigated. Furthermore, podman has its own squash functionality.