### PR TITLE
Better squashing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,3 @@ target
 .venv
 docker-squash.iml
 **/image.tar
-**/tox.tar

--- a/tests/test_unit_v1_image.py
+++ b/tests/test_unit_v1_image.py
@@ -1,6 +1,5 @@
 import builtins
 import pathlib
-import tarfile
 import unittest
 
 import mock
@@ -19,33 +18,39 @@ class TestSkippingFiles(unittest.TestCase):
 
     def test_should_skip_exact_files(self):
         ret = self.squash._file_should_be_skipped(
-            "/opt/webserver/something", [["/opt/eap", "/opt/webserver/something"]]
+            "/opt/webserver/something", {"/opt/eap", "/opt/webserver/something"}, set()
         )
-        self.assertEqual(ret, 1)
+        self.assertTrue(ret)
 
     def test_should_not_skip_file_not_in_path_to_skip(self):
         ret = self.squash._file_should_be_skipped(
-            "/opt/webserver/tmp", [["/opt/eap", "/opt/webserver/something"]]
+            "/opt/webserver/tmp", {"/opt/eap", "/opt/webserver/something"}, set()
         )
-        self.assertEqual(ret, 0)
+        self.assertFalse(ret)
 
     def test_should_not_skip_the_file_that_name_is_similar_to_skipped_path(self):
         ret = self.squash._file_should_be_skipped(
-            "/opt/webserver/tmp1234", [["/opt/eap", "/opt/webserver/tmp"]]
+            "/opt/webserver/tmp1234", {"/opt/eap", "/opt/webserver/tmp"}, set()
         )
-        self.assertEqual(ret, 0)
+        self.assertFalse(ret)
 
     def test_should_skip_files_in_subdirectory(self):
         ret = self.squash._file_should_be_skipped(
-            "/opt/webserver/tmp/abc", [["/opt/eap", "/opt/webserver/tmp"]]
+            "/opt/webserver/tmp/abc", {"/opt/eap", "/opt/webserver/tmp"}, set()
         )
-        self.assertEqual(ret, 1)
+        self.assertTrue(ret)
 
-    def test_should_skip_files_in_other_layer(self):
+    def test_should_skip_files_in_directory(self):
         ret = self.squash._file_should_be_skipped(
-            "/opt/webserver/tmp/abc", [["a"], ["b"], ["/opt/eap", "/opt/webserver/tmp"]]
+            "/opt/webserver/tmp/abc", {"/opt/eap"}, {"/opt/webserver/tmp"}
         )
-        self.assertEqual(ret, 3)
+        self.assertTrue(ret)
+
+    def test_should_not_skip_directory(self):
+        ret = self.squash._file_should_be_skipped(
+            "/opt/webserver/tmp/abc", {"/opt/eap"}, {"/opt/webserver/tmp/abc"}
+        )
+        self.assertFalse(ret)
 
 
 class TestParseImageName(unittest.TestCase):
@@ -205,16 +210,14 @@ class TestMarkerFiles(unittest.TestCase):
         for path in ["/opt/eap", "/opt/eap/one", "/opt/eap/.wh.to_skip"]:
             files.append(self._tar_member(path))
 
-        tar = mock.Mock()
-        markers = self.squash._marker_files(tar, files)
+        markers = self.squash._marker_files(files)
 
-        self.assertTrue(len(markers) == 1)
-        self.assertTrue(list(markers)[0].name == "/opt/eap/.wh.to_skip")
+        self.assertEqual(len(markers), 1)
+        self.assertEqual(markers[0].name, "/opt/eap/.wh.to_skip")
 
     def test_should_return_empty_dict_when_no_files_are_in_the_tar(self):
-        tar = mock.Mock()
-        markers = self.squash._marker_files(tar, [])
-        self.assertTrue(markers == {})
+        markers = self.squash._marker_files([])
+        self.assertEqual(len(markers), 0)
 
     def test_should_return_empty_dict_when_no_marker_files_are_found(self):
         files = []
@@ -222,168 +225,9 @@ class TestMarkerFiles(unittest.TestCase):
         for path in ["/opt/eap", "/opt/eap/one"]:
             files.append(self._tar_member(path))
 
-        tar = mock.Mock()
-        markers = self.squash._marker_files(tar, files)
+        markers = self.squash._marker_files(files)
 
-        self.assertTrue(len(markers) == 0)
-        self.assertTrue(markers == {})
-
-
-class TestAddMarkers(unittest.TestCase):
-    def setUp(self):
-        self.docker_client = mock.Mock()
-        self.log = mock.Mock()
-        self.image = "whatever"
-        self.squash = Image(self.log, self.docker_client, self.image, None)
-
-    def test_should_not_fail_with_empty_list_of_markers_to_add(self):
-        self.squash._add_markers({}, None, None, [])
-
-    def test_should_add_all_marker_files_to_empty_tar(self):
-        tar = mock.Mock()
-        tar.getnames.return_value = []
-
-        marker_1 = mock.Mock()
-        type(marker_1).name = mock.PropertyMock(return_value=".wh.marker_1")
-
-        markers = {marker_1: "file"}
-        self.squash._add_markers(markers, tar, {}, [])
-
-        self.assertTrue(len(tar.addfile.mock_calls) == 1)
-        tar_info, marker_file = tar.addfile.call_args[0]
-        self.assertIsInstance(tar_info, tarfile.TarInfo)
-        self.assertTrue(marker_file == "file")
-        self.assertTrue(tar_info.isfile())
-
-    def test_should_add_all_marker_files_to_empty_tar_besides_what_should_be_skipped(
-        self,
-    ):
-        tar = mock.Mock()
-        tar.getnames.return_value = []
-
-        marker_1 = mock.Mock()
-        type(marker_1).name = mock.PropertyMock(return_value=".wh.marker_1")
-        marker_2 = mock.Mock()
-        type(marker_2).name = mock.PropertyMock(return_value=".wh.marker_2")
-
-        markers = {marker_1: "file1", marker_2: "file2"}
-        self.squash._add_markers(
-            markers, tar, {"1234layerdid": ["/marker_1", "/marker_2"]}, [["/marker_1"]]
-        )
-
-        self.assertEqual(len(tar.addfile.mock_calls), 1)
-        tar_info, marker_file = tar.addfile.call_args[0]
-        self.assertIsInstance(tar_info, tarfile.TarInfo)
-        self.assertTrue(marker_file == "file2")
-        self.assertTrue(tar_info.isfile())
-
-    def test_should_skip_a_marker_file_if_file_is_in_unsquashed_layers(self):
-        tar = mock.Mock()
-        # List of files in the squashed tar
-        tar.getnames.return_value = ["marker_1"]
-
-        marker_1 = mock.Mock()
-        type(marker_1).name = mock.PropertyMock(return_value=".wh.marker_1")
-        marker_2 = mock.Mock()
-        type(marker_2).name = mock.PropertyMock(return_value=".wh.marker_2")
-        # List of marker files to add back
-        markers = {marker_1: "marker_1", marker_2: "marker_2"}
-        # List of files in all layers to be moved
-        files_in_moved_layers = {"1234layerdid": ["/some/file", "/marker_2"]}
-        self.squash._add_markers(markers, tar, files_in_moved_layers, [])
-
-        self.assertEqual(len(tar.addfile.mock_calls), 1)
-        tar_info, marker_file = tar.addfile.call_args[0]
-        self.assertIsInstance(tar_info, tarfile.TarInfo)
-        self.assertTrue(marker_file == "marker_2")
-        self.assertTrue(tar_info.isfile())
-
-    def test_should_not_add_any_marker_files(self):
-        tar = mock.Mock()
-        tar.getnames.return_value = ["marker_1", "marker_2"]
-
-        marker_1 = mock.Mock()
-        type(marker_1).name = mock.PropertyMock(return_value=".wh.marker_1")
-        marker_2 = mock.Mock()
-        type(marker_2).name = mock.PropertyMock(return_value=".wh.marker_2")
-
-        markers = {marker_1: "file1", marker_2: "file2"}
-        self.squash._add_markers(
-            markers, tar, {"1234layerdid": ["some/file", "marker_1", "marker_2"]}, []
-        )
-
-        self.assertTrue(len(tar.addfile.mock_calls) == 0)
-
-    # https://github.com/goldmann/docker-squash/issues/108
-    def test_should_add_marker_file_when_tar_has_prefixed_entries(self):
-        tar = mock.Mock()
-        # Files already in tar
-        tar.getnames.return_value = ["./abc", "./def"]
-
-        marker_1 = mock.Mock()
-        type(marker_1).name = mock.PropertyMock(return_value=".wh.some/file")
-        marker_2 = mock.Mock()
-        type(marker_2).name = mock.PropertyMock(return_value=".wh.file2")
-
-        markers = {marker_1: "filecontent1", marker_2: "filecontent2"}
-
-        # List of layers to move (and files in these layers), already normalized
-        self.squash._add_markers(
-            markers, tar, {"1234layerdid": ["/some/file", "/other/file", "/stuff"]}, []
-        )
-
-        self.assertEqual(len(tar.addfile.mock_calls), 1)
-        tar_info, marker_file = tar.addfile.call_args[0]
-        self.assertIsInstance(tar_info, tarfile.TarInfo)
-        # We need to add the marker file because we need to
-        # override the already existing file
-        self.assertEqual(marker_file, "filecontent1")
-        self.assertTrue(tar_info.isfile())
-
-
-class TestReduceMarkers(unittest.TestCase):
-    def setUp(self):
-        self.docker_client = mock.Mock()
-        self.log = mock.Mock()
-        self.image = "whatever"
-        self.squash = Image(self.log, self.docker_client, self.image, None)
-
-    def test_should_not_reduce_any_marker_files(self):
-        marker_1 = mock.Mock()
-        type(marker_1).name = mock.PropertyMock(return_value=".wh.some/file")
-        marker_2 = mock.Mock()
-        type(marker_2).name = mock.PropertyMock(return_value=".wh.file2")
-
-        markers = {marker_1: "filecontent1", marker_2: "filecontent2"}
-
-        self.squash._reduce(markers)
-
-        assert len(markers) == 2
-        assert markers[marker_1] == "filecontent1"
-        assert markers[marker_2] == "filecontent2"
-
-    def test_should_reduce_marker_files(self):
-        marker_1 = mock.Mock()
-        type(marker_1).name = mock.PropertyMock(return_value="opt/.wh.testing")
-        marker_2 = mock.Mock()
-        type(marker_2).name = mock.PropertyMock(
-            return_value="opt/testing/something/.wh.file"
-        )
-        marker_3 = mock.Mock()
-        type(marker_3).name = mock.PropertyMock(
-            return_value="opt/testing/something/.wh.other_file"
-        )
-
-        markers = {
-            marker_1: "filecontent1",
-            marker_2: "filecontent2",
-            marker_3: "filecontent3",
-        }
-
-        self.squash._reduce(markers)
-
-        assert len(markers) == 1
-        assert markers[marker_1] == "filecontent1"
+        self.assertEqual(len(markers), 0)
 
 
 class TestPathHierarchy(unittest.TestCase):

--- a/tests/test_unit_v2_image.py
+++ b/tests/test_unit_v2_image.py
@@ -11,8 +11,7 @@ class TestReadingConfigFiles(unittest.TestCase):
     def setUp(self):
         self.docker_client = mock.Mock()
         self.log = mock.Mock()
-        self.image = "whatever"
-        self.image = V2Image(self.log, self.docker_client, self.image, None)
+        self.image = V2Image(self.log, self.docker_client, "whatever", None)
 
     def test_should_read_json_file(self):
         manifest_example = '[{"Config":"96bdd3be20fa51b22dc9aaf996b49d403a403adf96e35d7e8b98519267c21c21.json","RepoTags":["busybox-to-squash:squashed"],"Layers":["980a6c63f88351bea42851fc101e4e2f61b12e1bf70122aad1f25186a736a404/layer.tar","977b2156300ec11226ffc7f9382e2fe4ec10a9cdfe445e062542b430aa09d82d/layer.tar","8a646a2ab402ca2774063c602182ad22c09d4af236ed84bdddb6d1205309accf/layer.tar"]}]'
@@ -47,8 +46,7 @@ class TestGeneratingMetadata(unittest.TestCase):
     def setUp(self):
         self.docker_client = mock.Mock()
         self.log = mock.Mock()
-        self.image = "whatever"
-        self.image = V2Image(self.log, self.docker_client, self.image, None)
+        self.image = V2Image(self.log, self.docker_client, "whatever", None)
 
     def test_generate_manifest(self):
         old_image_manifest = {
@@ -238,8 +236,7 @@ class TestWritingMetadata(unittest.TestCase):
     def setUp(self):
         self.docker_client = mock.Mock()
         self.log = mock.Mock()
-        self.image = "whatever"
-        self.image = V2Image(self.log, self.docker_client, self.image, None)
+        self.image = V2Image(self.log, self.docker_client, "whatever", None)
 
     @mock.patch.object(V2Image, "_write_json_metadata")
     def test_write_image_metadata(self, mock_method):


### PR DESCRIPTION
1) Updated github runner to ubuntu-22.04 (ubuntu-20.04 is no longer supported). Unfortunately, it does not have python 3.6
2) Added a couple of new tests (https://github.com/goldmann/docker-squash/issues/253 and a few others)
3) Reworked squashing process:
    - Replaced lists with sets in some places
    - Removed special handling of symlinks. Broken symlinks are fine, we don't need to delete them
    - Added hardlink to regular file conversion, simplifying things a lot. It shouldn't affect much, considering docker already does that conversion if you try to create link to a file from another layer
    - Squashing now only takes a single pass, no need to return to the previous layers to add back some skipped files (https://github.com/goldmann/docker-squash/issues/64 is now doable, I guess?)

There are a lot of changes, so we have to check that everything still works as expected. I don't think that existing tests cover all the corner cases and possible bugs. And it would be nice to run some benchmarking to see whether the new solution is faster or not